### PR TITLE
Comment Out Non-working Seed Node in lib.js Due to SSL Certificate Error

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -14,10 +14,11 @@ const seedNodeList = [
     ip_url: 'http://116.203.53.213/',
     url: 'https://storage.seed1.loki.network/json_rpc'
   },
+/* Currently not working: NET::ERR_CERT_COMMON_NAME_INVALID   
   {
     ip_url: 'http://212.199.114.66/',
     url: 'https://storage.seed3.loki.network/json_rpc'
-  },
+  }, */
   {
     ip_url: 'http://144.76.164.202/',
     url: 'https://public.loki.foundation/json_rpc'


### PR DESCRIPTION
#### Summary:
This pull request comments out the seed node `https://storage.seed3.loki.network/json_rpc` in the `lib.js` file. The node is causing a TLS certificate issue (`ERR_TLS_CERT_ALTNAME_INVALID`), leading to an uncaught TypeError in the function `getStorageServersFromSeed`.

#### Details:
- **File Affected:** `lib.js`
- **Code Block:** Inside the `seedNodeList` array
- **Issue:** The application runs into a TLS certificate error (`ERR_TLS_CERT_ALTNAME_INVALID`), specifically affecting the function `getStorageServersFromSeed`.
- **Error Log:** 
  - `lib::textAsk - err FetchError {message: ... , code: 'ERR_TLS_CERT_ALTNAME_INVALID'}`
  - `Uncaught TypeError: Cannot read properties of undefined (reading 'result')`
- **Resolution:** The problematic seed node has been commented out to temporarily resolve the issue.
- **Impact:** No negative impact is expected as the resource was already causing errors.

#### Next Steps:
- Investigate the root cause of the TLS certificate issue (`ERR_TLS_CERT_ALTNAME_INVALID`).